### PR TITLE
支持莫干山校区的空教室查询

### DIFF
--- a/app/Http/Controllers/Ycjw/FreeroomController.php
+++ b/app/Http/Controllers/Ycjw/FreeroomController.php
@@ -15,6 +15,15 @@ class FreeroomController extends Controller
         }
         $ext = $user->ext;
         $area = $request->get('area');
+
+        $acturalArea = '';
+        // 01: 朝晖, 02: 屏峰, 03: 莫干山
+        if ($area == '01' || $area == '02') {
+            $acturalArea = $area;
+        }  else if ($area == '03') {
+            $acturalArea = 'A61400B98155D41AE0550113465EF1CF';
+        }
+
         $startTime  = $request->get('startTime');
         $endTime  = $request->get('endTime');
         $weekday  = $request->get('weekday');
@@ -26,7 +35,7 @@ class FreeroomController extends Controller
         }
         $term = config('system.current_term');
         $api = new Api();
-        $freeroomData = $api->getFreeRoom($user->uno, decrypt($ext['passwords']['zf_password']), $term, $area, $startTime, $endTime, $weekday, $week);
+        $freeroomData = $api->getFreeRoom($user->uno, decrypt($ext['passwords']['zf_password']), $term, $acturalArea, $startTime, $endTime, $weekday, $week);
         $errmsg = $api->getError();
         if($errmsg) {
             return RJM(null, -1, $errmsg);


### PR DESCRIPTION
## 支持莫干山校区的空教室查询

接口：`/api/freeroom`，调用方式与先前保持一致：`area` 字段 `01` 为朝晖，`02` 为屏峰，新增 `03` 值代表莫干山校区。正方上莫干山校区的 id 看着很奇怪，为防止发生变化时需要更新客户端，在服务端上对 id 做了一层转换。