### PR TITLE
iOS「添加到桌面」功能

### DIFF
--- a/public/ios-homescreen/index.html
+++ b/public/ios-homescreen/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="zh-cn">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>把微精弘装进桌面</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-585DSGLZ6Q"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-585DSGLZ6Q");
+    </script>
+    <style>
+      .guide-icon {
+        width: 1rem;
+        height: 1rem;
+        margin-bottom: 2px;
+      }
+      body {
+        background: linear-gradient(180deg, #e0eafc, #cfdef3);
+        background-color: #e0eafc;
+        color: #00243d;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container-guide" class="container-fluid vh-100">
+      <div class="row">
+        <div class="col col-10 col-lg-8 col-xl-6 mx-auto text-center">
+          <div
+            id="content-extern"
+            class="vh-100 d-flex flex-column align-items-center justify-content-center text-center"
+            style="display: none !important"
+          >
+            <img
+              src="https://assets.gettoset.cn/wejh/ios-homescreen/images/open-in-safari.png"
+              class="w-75 mb-3"
+              alt=""
+            />
+            <div>请使用iOS设备访问，并选择在Safari中打开</div>
+          </div>
+          <div id="content-guide" style="display: none !important">
+            <div class="mt-4">
+              <h2 class="font-weight-bold">把微精弘装进桌面</h2>
+            </div>
+            <div class="mt-4">
+              <img
+                src="https://assets.gettoset.cn/wejh/ios-homescreen/images/wejh-preview.png"
+                class="w-75"
+                alt=""
+              />
+            </div>
+            <div class="mt-4">
+              <small
+                >点击<strong>「下一步」</strong>，当看到精弘 Logo
+                时，点击浏览器上的<img
+                  src="https://assets.gettoset.cn/wejh/ios-homescreen/images/guide-icon-share.png"
+                  class="guide-icon"
+                  alt=""
+                />按钮，并选择<img
+                  src="https://assets.gettoset.cn/wejh/ios-homescreen/images/guide-icon-add.png"
+                  class="guide-icon"
+                  alt=""
+                /><strong>「添加到主屏幕」</strong></small
+              >
+            </div>
+            <div class="mt-3">
+              <button
+                type="button"
+                class="btn btn-primary btn-block"
+                id="guide-btn-continue"
+              >
+                下一步
+              </button>
+              <div class="form-group form-check mt-2">
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  id="guide-checkbox"
+                />
+                <label class="form-check-label" for="guide-checkbox">
+                  我知道如何操作啦
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      window.addEventListener("load", function () {
+        var userAgent = navigator.userAgent;
+        var isIOSAndSafari =
+          /iPad|iPhone|iPod/.test(userAgent) &&
+          /.*Version.*Safari.*/.test(userAgent) &&
+          !/CriOS/.test(userAgent) &&
+          !/FxiOS/.test(userAgent) &&
+          !/EdgiOS/.test(userAgent) &&
+          !/OPiOS/.test(userAgent);
+
+        if (isIOSAndSafari) {
+          document.getElementById("content-guide").setAttribute("style", "");
+        } else {
+          document.getElementById("content-extern").setAttribute("style", "");
+        }
+
+        var continueButton = document.getElementById("guide-btn-continue");
+        var guideCheckbox = document.getElementById("guide-checkbox");
+        continueButton.disabled = !guideCheckbox.checked;
+        guideCheckbox.addEventListener("change", function () {
+          continueButton.disabled = !this.checked;
+        });
+        continueButton.addEventListener("click", function () {
+          window.location.href = "./launcher";
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/public/ios-homescreen/launcher/index.html
+++ b/public/ios-homescreen/launcher/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>微精弘</title>
+    <meta name="apple-touch-fullscreen" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width,viewport-fit=cover,initial-scale=1,minimum-scale=1,maximum-scale=1,minimal-ui"
+    />
+    <link
+      href="https://assets.gettoset.cn/wejh/ios-homescreen/launcher/images/wejh_ios_icon.png"
+      sizes="180x180"
+      rel="apple-touch-icon-precomposed"
+    />
+  </head>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+    }
+    body,
+    html {
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      text-align: center;
+    }
+    .container {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container .splash {
+      background-image: url("https://assets.gettoset.cn/wejh/ios-homescreen/launcher/images/launcher-splash.png");
+      background-size: cover;
+      width: 190px;
+      height: 190px;
+    }
+    @media (prefers-color-scheme: light) {
+      html {
+        background: #e882af;
+      }
+    }
+    @media (prefers-color-scheme: dark) {
+      html {
+        background: #000000;
+      }
+    }
+  </style>
+  <body>
+    <div class="container">
+      <div class="splash"></div>
+    </div>
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("sw.js");
+      }
+      function navigateToWejh() {
+        window.location.href = "weixin://dl/business/?t=uKnrbtNaRoq";
+      }
+      if (window.navigator.standalone) {
+        setTimeout(() => {
+          navigateToWejh();
+        }, 500);
+        window.addEventListener(
+          "focus",
+          function () {
+            navigateToWejh();
+          },
+          false
+        );
+      } else {
+        //
+      }
+    </script>
+  </body>
+</html>

--- a/public/ios-homescreen/launcher/sw.js
+++ b/public/ios-homescreen/launcher/sw.js
@@ -1,0 +1,69 @@
+// Names of the two caches used in this version of the service worker.
+// Change to v2, etc. when you update any of the local resources, which will
+// in turn trigger the install event again.
+const PRECACHE = "precache-v1";
+const RUNTIME = "runtime-v1";
+
+// A list of local resources we always want to be cached.
+const PRECACHE_URLS = [
+  "index.html",
+  "./", // Alias for index.html
+];
+
+// The install handler takes care of precaching the resources we always need.
+self.addEventListener("install", (event) => {
+  event.waitUntil(async () => {
+    await (await caches.open()).addAll(PRECACHE_URLS);
+  });
+});
+
+// The activate handler takes care of cleaning up old caches.
+self.addEventListener("activate", (event) => {
+  const currentCaches = [PRECACHE, RUNTIME];
+  event.waitUntil(async () => {
+    const cachesToDelete = await (await caches.keys()).filter(
+      (cacheName) => !currentCaches.includes(cacheName)
+    );
+    await Promise.all(
+      cachesToDelete.map((cacheToDelete) => {
+        return caches.delete(cacheToDelete);
+      })
+    );
+    await self.clients.claim();
+  });
+});
+
+addEventListener("fetch", function (e) {
+  e.respondWith(
+    (async () => {
+      const cachedResponse = await caches.match(e.request);
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      const networkResponse = await fetch(e.request);
+
+      const hosts = ["https://assets.gettoset.cn"];
+
+      const url = e.request.url;
+      if (
+        url.startsWith(self.location.origin) ||
+        hosts.some((host) => url.startsWith(host))
+      ) {
+        // This clone() happens before `return networkResponse`
+        const clonedResponse = networkResponse.clone();
+
+        e.waitUntil(
+          (async () => {
+            const cache = await caches.open(RUNTIME);
+            // This will be called after `return networkResponse`
+            // so make sure you already have the clone!
+            await cache.put(e.request, clonedResponse);
+          })()
+        );
+      }
+
+      return networkResponse;
+    })()
+  );
+});


### PR DESCRIPTION
包含三个静态文件：

- `/ios-homescreen/launcher/index.html`：启动器，页面显示适配了 DarkMode 的精弘 Logo，检测 iOS 主屏环境，并自动通过 schema 跳转到小程序，跳转目标为 `/pages/index/index?utm_source=ios-homescreen&utm_medium=homescreen&utm_campaign=launcher`
- `/ios-homescreen/launcher/sw.js`：Service Worker，用于离线化，防止用户断网时打开白屏
- `/ios-homescreen/index.html`：用于引导用户将启动器页面以书签的形式放到主页，检测到 iOS 设备的 Safari 环境时显示引导，用户点击按钮后跳转到启动器页面。页面内有 Bootstrap（通过 jsDelivr CDN 导入）和谷歌分析。

<img width="1093" alt="截屏2021-01-26 下午11 57 06" src="https://user-images.githubusercontent.com/8158163/105869486-3f34fa80-6032-11eb-9668-9e77788a8089.png">