### PR TITLE
成绩查询去掉登录失败的重定向，修改提示文本

### DIFF
--- a/app/Http/Controllers/Ycjw/ScoreController.php
+++ b/app/Http/Controllers/Ycjw/ScoreController.php
@@ -47,7 +47,7 @@ class ScoreController extends Controller
                 return RJM(null, -1, '需要绑定');
             }
             if($api->getError() == '用户名或密码错误') {
-                return RJM(null, -1, '请重新绑定正方账号', '/pages/bind/zf');
+                return RJM(null, -1, '登录正方教务失败');
             }
             return RJM(null, -1, $api->getError());
         }


### PR DESCRIPTION
成绩查询登录失败时，错误提示从「请重新绑定正方账号」修改为「登录正方教务失败」，并去掉了重定向。

因为验证码导致的登录失败也会走到这个位置，很多人跳转到了正方绑定的界面之后会感到 confused。