### PR TITLE
成绩/成绩详细查询支持传递特定学期

### DIFF
--- a/app/Http/Controllers/Ycjw/ScoreController.php
+++ b/app/Http/Controllers/Ycjw/ScoreController.php
@@ -30,7 +30,6 @@ class ScoreController extends Controller
             $semester_req = intval($request->get('term_semester'));
             if ($semester_req) {
                 $term = "$term_year_req/".($term_year_req + 1)."($semester_req)";
-                error_log($term);
             } else {
                 return RJM(null, -1, '参数错误');
             }
@@ -105,7 +104,6 @@ class ScoreController extends Controller
             $semester_req = intval($request->get('term_semester'));
             if ($semester_req) {
                 $term = "$term_year_req/".($term_year_req + 1)."($semester_req)";
-                error_log($term);
             } else {
                 return RJM(null, -1, '参数错误');
             } 

--- a/app/Http/Controllers/Ycjw/ScoreController.php
+++ b/app/Http/Controllers/Ycjw/ScoreController.php
@@ -21,20 +21,33 @@ class ScoreController extends Controller
                 'term' => '2013/2014(1)',
             ], 1, '获取成绩成功');
         }
-        $start_grade = intval(substr($user->uno, 0, 4));
+
         $ext = $user->ext;
-        $term = $ext['terms']['score_term'];
-        preg_match_all('/\d+/', $term, $pregResult);
-        $year = intval($pregResult[0][0]);
-        if ($start_grade <= 2013 && $year > 2016) {
-            $term = '2016/2017(2)';
-            $user->setExt('terms.score_term', $term);
-        } else if ($start_grade >= 2017 && $year <= 2016) {
-            $term = '2017/2018(1)';
-            $user->setExt('terms.score_term', $term);
-        } else if ($year <= 2016 && $user->uno == '201603090210') {
-            $term = '2017/2018(1)';
-            $user->setExt('terms.score_term', $term);
+        $start_grade = intval(substr($user->uno, 0, 4));
+
+        $term_year_req = intval($request->get('term_year'));
+        if ($term_year_req) {
+            $semester_req = intval($request->get('term_semester'));
+            if ($semester_req) {
+                $term = "$term_year_req/".($term_year_req + 1)."($semester_req)";
+                error_log($term);
+            } else {
+                return RJM(null, -1, '参数错误');
+            }
+        } else {
+            $term = $ext['terms']['score_term'];
+            preg_match_all('/\d+/', $term, $pregResult);
+            $year = intval($pregResult[0][0]);
+            if ($start_grade <= 2013 && $year > 2016) {
+                $term = '2016/2017(2)';
+                $user->setExt('terms.score_term', $term);
+            } else if ($start_grade >= 2017 && $year <= 2016) {
+                $term = '2017/2018(1)';
+                $user->setExt('terms.score_term', $term);
+            } else if ($year <= 2016 && $user->uno == '201603090210') {
+                $term = '2017/2018(1)';
+                $user->setExt('terms.score_term', $term);
+            }
         }
 
         $api = new Api;
@@ -53,7 +66,10 @@ class ScoreController extends Controller
         }
 
         $term_grade = intval(substr($term, 0, 4));
-        $grade_list = ['一', '二', '三', '四'];
+        $semester_grade = intval(substr($term, 10, 1));
+
+        $grade_list = ['一', '二', '三', '四', '五', '六'];
+        $semester_list = ['上', '下', '短'];
 
         if(isset($grade_list[$term_grade - $start_grade])) {
             $grade_name = $grade_list[$term_grade - $start_grade];
@@ -61,7 +77,12 @@ class ScoreController extends Controller
             $grade_name = '？';
         }
 
-        $semester = substr($term, 10, 1) == 1 ? '上' : '下';
+        if(isset($semester_list[$semester_grade - 1])) {
+            $semester = $semester_list[$semester_grade - 1];
+        } else {
+            $semester = '？';
+        }
+
         $arr = [
             'grade_name' => $grade_name,
             'semester' => $semester,
@@ -71,22 +92,35 @@ class ScoreController extends Controller
         return RJM($res, 1, '获取成绩成功');
     }
 
-
     public function detail(Request $request) {
         if(!$user = Auth::user()) {
             return RJM(null, -1, '没有认证信息');
         }
-        $start_grade = intval(substr($user->uno, 0, 4));
+
         $ext = $user->ext;
-        $term = $ext['terms']['score_term'];
-        preg_match_all('/\d+/', $term, $pregResult);
-        $year = intval($pregResult[0][0]);
-        if ($start_grade <= 2013) {
-            return RJM(null, -1, '2013级以前学生无法使用明细功能');
-        } else if ($year <= 2016) {
-            $term = '2017/2018(1)';
-            $user->setExt('terms.score_term', $term);
+        $start_grade = intval(substr($user->uno, 0, 4));
+
+        $term_year_req = intval($request->get('term_year'));
+        if ($term_year_req) {
+            $semester_req = intval($request->get('term_semester'));
+            if ($semester_req) {
+                $term = "$term_year_req/".($term_year_req + 1)."($semester_req)";
+                error_log($term);
+            } else {
+                return RJM(null, -1, '参数错误');
+            } 
+        } else {
+            $term = $ext['terms']['score_term'];
+            preg_match_all('/\d+/', $term, $pregResult);
+            $year = intval($pregResult[0][0]);
+            if ($start_grade <= 2013) {
+                return RJM(null, -1, '2013级以前学生无法使用明细功能');
+            } else if ($year <= 2016) {
+                $term = '2017/2018(1)';
+                $user->setExt('terms.score_term', $term);
+            }
         }
+
         $api = new Api;
         $score_result = $api->getUEASData('scoreDetail', $user->uno, [
             'yc' => $ext['passwords']['yc_password'] ? decrypt($ext['passwords']['yc_password']) : '',
@@ -97,13 +131,16 @@ class ScoreController extends Controller
                 return RJM(null, -1, '需要绑定');
             }
             if($api->getError() == '用户名或密码错误') {
-                return RJM(null, -1, '请重新绑定正方账号');
+                return RJM(null, -1, '登录正方教务失败');
             }
             return RJM(null, -1, $api->getError());
         }
 
         $term_grade = intval(substr($term, 0, 4));
-        $grade_list = ['一', '二', '三', '四'];
+        $semester_grade = intval(substr($term, 10, 1));
+
+        $grade_list = ['一', '二', '三', '四', '五', '六'];
+        $semester_list = ['上', '下', '短'];
 
         if(isset($grade_list[$term_grade - $start_grade])) {
             $grade_name = $grade_list[$term_grade - $start_grade];
@@ -111,7 +148,12 @@ class ScoreController extends Controller
             $grade_name = '？';
         }
 
-        $semester = substr($term, 10, 1) == 1 ? '上' : '下';
+        if(isset($semester_list[$semester_grade - 1])) {
+            $semester = $semester_list[$semester_grade - 1];
+        } else {
+            $semester = '？';
+        }
+
         $arr = [
             'grade_name' => $grade_name,
             'semester' => $semester,

--- a/app/Models/Api.php
+++ b/app/Models/Api.php
@@ -245,10 +245,14 @@ class Api extends Model
             } else {
                 // 原创查询逻辑
                 $termNum = intval($pregResult[0][2]);
-                if (!($termNum === 1 || $term === 2)) {
+                if (!($termNum === 1 || $termNum === 2)) {
                     // 原创教务只允许查询上/下学期数据
-                    return $this->setError('参数错误');
-                }
+                    if ($termNum === 3) {
+                        return $this->setError('原创教务不支持短学期查询');
+                    } else {
+                        return $this->setError('参数错误');
+                    }
+                } 
                 $timeout = $timeout === null ? 800 : $timeout;
                 $func = 'get' . 'Yc' . ucwords($type);
                 if (!$password['yc']) {


### PR DESCRIPTION
成绩/成绩详细查询支参数持传递特定学期

GET: `/api/ycjw/score?term_year=2020&term_semester=2`
GET: `/api/ycjw/scoreDetail?term_year=2020&term_semester=2`

- `term_year`: 查询学年（2020 表示 2020/2021）
- `term_semester`: 查询学期（1、2、3 分别表示上、下、短）

**`term_year` 不提供时，走原有逻辑（从用户 `ext` 字段读出学期），只提供 `term_year` 返回参数错误**