### PR TITLE
考试安排支持查询特定学期

### DIFF
--- a/app/Http/Controllers/Ycjw/ExamController.php
+++ b/app/Http/Controllers/Ycjw/ExamController.php
@@ -14,7 +14,6 @@ class ExamController extends Controller
         if(!$user = Auth::user()) {
             return RJM(null, -1, '没有认证信息');
         }
-
         if (isTestAccount($user->uno)) {
             return  RJM([
                 'list' => [],
@@ -23,37 +22,47 @@ class ExamController extends Controller
                 'term' => '2013/2014(1)',
             ], 1, '获取排考成功');
         }
-        $ext = $user->ext;
-        $term = $ext['terms']['exam_term'];
 
+        $ext = $user->ext;
         $start_grade = intval(substr($user->uno, 0, 4));
-        preg_match_all('/\d+/', $term, $pregResult);
-        $year = intval($pregResult[0][0]);
-        if ($start_grade <= 2013 && $year > 2016) {
-            $term = '2016/2017(2)';
-            $user->setExt('terms.exam_term', $term);
-        } else if ($start_grade >= 2017 && $year <= 2016) {
-            $term = '2017/2018(1)';
-            $user->setExt('terms.exam_term', $term);
+
+        $term_year_req = intval($request->get('term_year'));
+        if ($term_year_req) {
+            $semester_req = intval($request->get('term_semester'));
+            if ($semester_req) {
+                $term = "$term_year_req/".($term_year_req + 1)."($semester_req)";
+            } else {
+                return RJM(null, -1, '参数错误');
+            }
+        } else {
+            $term = $ext['terms']['exam_term'];
+            preg_match_all('/\d+/', $term, $pregResult);
+            $year = intval($pregResult[0][0]);
+            if ($start_grade <= 2013 && $year > 2016) {
+                $term = '2016/2017(2)';
+                $user->setExt('terms.exam_term', $term);
+            } else if ($start_grade >= 2017 && $year <= 2016) {
+                $term = '2017/2018(1)';
+                $user->setExt('terms.exam_term', $term);
+            }
         }
+
         $api = new Api;
         $exam_result = $api->getUEASData('exam', $user->uno, [
             'yc' => $ext['passwords']['yc_password'] ? decrypt($ext['passwords']['yc_password']) : '',
             'zf' => $ext['passwords']['zf_password'] ? decrypt($ext['passwords']['zf_password']) : ''
         ], $term, null, true, null);
-
         if(!$exam_result) {
             if($api->getError() == '用户名或密码为空') {
                 return RJM(null, -1, '需要绑定');
             }
             if($api->getError() == '用户名或密码错误') {
-                return RJM(null, -1, '请重新绑定正方账号');
+                return RJM(null, -1, '登录正方教务失败');
             }
             return RJM(null, -1, $api->getError());
         }
 
         $exam_result['term'] = $term;
-
         return RJM($exam_result, 1, '获取排考成功');
     }
 


### PR DESCRIPTION
排考查询支参数持传递特定学期

GET: `/api/ycjw/exam?term_year=2020&term_semester=2`

- `term_year`: 查询学年（如 2020 表示 2020/2021）
- `term_semester`: 查询学期（1、2、3 分别表示上、下、短）

**`term_year` 不提供时，走原有逻辑（从用户 `ext` 字段读出学期），只提供 `term_year` 返回参数错误**